### PR TITLE
Remove double padding in mapping menu

### DIFF
--- a/bundle/Resources/sass/ezadminui/_rules.scss
+++ b/bundle/Resources/sass/ezadminui/_rules.scss
@@ -495,7 +495,7 @@
         padding-right: 0;
     }
 
-    .rule-link-layout {
+    .rule-padded-left {
         display: flex;
         padding: 10px 20px;
         font-size: 12px;


### PR DESCRIPTION
This pull request fixes issues with padding introduced by the changes made in netgen-layouts/layouts-core#25.